### PR TITLE
(#2) Add Aircraft Orientation data to State Vector

### DIFF
--- a/Simulation/Derivatives.m
+++ b/Simulation/Derivatives.m
@@ -1,4 +1,4 @@
-function StateVector_Dot = Derivatives(StateVector, Object)
+function StateVector_dot = Derivatives(StateVector, Object)
   Velocity = P_dot = StateVector(3:4); % Derivative of position is velocity
   Speed    = norm(Velocity);           % Magnitude of velocity vector
 
@@ -21,7 +21,7 @@ function StateVector_Dot = Derivatives(StateVector, Object)
  
   V_dot = Gravity + F / Object.Mass; % Derivative of velocity is acceleration
 
-  Orientation_dot = [0]; % TODO: Need to add proper math here (torque)
+  O_dot = [0]; % TODO: Need to add proper math here (torque)
   
-  StateVector_Dot = [P_dot, V_dot, Orientation_dot];
+  StateVector_dot = [P_dot, V_dot, O_dot];
 endfunction

--- a/Simulation/Derivatives.m
+++ b/Simulation/Derivatives.m
@@ -21,5 +21,7 @@ function StateVector_Dot = Derivatives(StateVector, Object)
  
   V_dot = Gravity + F / Object.Mass; % Derivative of velocity is acceleration
 
-  StateVector_Dot = [P_dot, V_dot];
+  Orientation_dot = [0]; % TODO: Need to add proper math here (torque)
+  
+  StateVector_Dot = [P_dot, V_dot, Orientation_dot];
 endfunction

--- a/Simulation/Main.m
+++ b/Simulation/Main.m
@@ -6,16 +6,16 @@ Plane.AeroRefArea = 1; % Cross sectional area used for calculation of aerodynami
 Plane.Cd          = 1; % Coefficient of drag (dimensionless)
 Plane.Cl          = 0; % Coefficient of lift (dimensionless)
 
-printf('Terminal velocity: %d m/s\n', 
+printf('Terminal velocity: %d m/s\n',
         sqrt((2 * Plane.Mass * 9.81) / (Plane.Cd * 1.225 * Plane.AeroRefArea)));
 
 % State vector initialization
 % X - left/right, Y - up/down
-P0          = [0, 10]; % Initial position (m)
-V0          = [0, 0];  % Initial velocity (m/s)
-Orientation = [0];     % Initial orientation, currently just pitch (deg)
+P0 = [0, 10]; % Initial position (m)
+V0 = [0, 0];  % Initial velocity (m/s)
+O0 = [0];     % Initial orientation, currently just pitch (deg)
 
-StateVector = [P0, V0, Orientation];
+StateVector = [P0, V0, O0];
 
 % Results used for plotting
 Results.X     = StateVector(1);
@@ -23,7 +23,7 @@ Results.Y     = StateVector(2);
 Results.Vx    = StateVector(3);
 Results.Vy    = StateVector(4);
 Results.Pitch = StateVector(5);
-Results.Time = 0;
+Results.Time  = 0;
 
 % Simulation parameters
 dt = 0.05;         % Step time (s)
@@ -33,7 +33,7 @@ ground_height = 0; % Height of the ground (m)
 for i=2:(end_time / dt)
   % Integrate next step
   StateVector = RK4_Integration(StateVector, Plane, dt);
-  
+
   % Save Results
   Results.X(i)     = StateVector(1);
   Results.Y(i)     = StateVector(2);
@@ -41,7 +41,7 @@ for i=2:(end_time / dt)
   Results.Vy(i)    = StateVector(4);
   Results.Pitch(i) = StateVector(5);
   Results.Time(i)  = dt * (i - 1);
-  
+
   % Check if object has hit the ground
   if StateVector(2) < ground_height
     printf('Ground hit in %d s\n', Results.Time(end))

--- a/Simulation/Main.m
+++ b/Simulation/Main.m
@@ -6,20 +6,23 @@ Plane.AeroRefArea = 1; % Cross sectional area used for calculation of aerodynami
 Plane.Cd          = 1; % Coefficient of drag (dimensionless)
 Plane.Cl          = 0; % Coefficient of lift (dimensionless)
 
-printf('Terminal velocity: %d m/s\n', sqrt((2 * Plane.Mass * 9.81) / (Plane.Cd * 1.225 * Plane.AeroRefArea)));
+printf('Terminal velocity: %d m/s\n', 
+        sqrt((2 * Plane.Mass * 9.81) / (Plane.Cd * 1.225 * Plane.AeroRefArea)));
 
 % State vector initialization
 % X - distance, Y - height
-P0 = [0, 10]; % Initial position (m)
-V0 = [0, 0]; % Initial velocity (m/s)
+P0 = [0, 10];      % Initial position (m)
+V0 = [0, 0];       % Initial velocity (m/s)
+Orientation = [0]; % Initial orientation, currently just pitch (deg)
 
-StateVector = [P0, V0];
+StateVector = [P0, V0, Orientation];
 
 % Results used for plotting
-Results.X    = StateVector(1);
-Results.Y    = StateVector(2);
-Results.Vx   = StateVector(3);
-Results.Vy   = StateVector(4);
+Results.X     = StateVector(1);
+Results.Y     = StateVector(2);
+Results.Vx    = StateVector(3);
+Results.Vy    = StateVector(4);
+Results.Pitch = StateVector(5);
 Results.Time = 0;
 
 % Simulation parameters
@@ -32,11 +35,12 @@ for i=2:(end_time / dt)
   StateVector = RK4_Integration(StateVector, Plane, dt);
   
   % Save Results
-  Results.X(i)    = StateVector(1);
-  Results.Y(i)    = StateVector(2);
-  Results.Vx(i)   = StateVector(3);
-  Results.Vy(i)   = StateVector(4);
-  Results.Time(i) = dt * (i - 1);
+  Results.X(i)     = StateVector(1);
+  Results.Y(i)     = StateVector(2);
+  Results.Vx(i)    = StateVector(3);
+  Results.Vy(i)    = StateVector(4);
+  Results.Pitch(i) = StateVector(5);
+  Results.Time(i)  = dt * (i - 1);
   
   % Check if object has hit the ground
   if StateVector(2) < ground_height

--- a/Simulation/Main.m
+++ b/Simulation/Main.m
@@ -10,10 +10,10 @@ printf('Terminal velocity: %d m/s\n',
         sqrt((2 * Plane.Mass * 9.81) / (Plane.Cd * 1.225 * Plane.AeroRefArea)));
 
 % State vector initialization
-% X - distance, Y - height
-P0 = [0, 10];      % Initial position (m)
-V0 = [0, 0];       % Initial velocity (m/s)
-Orientation = [0]; % Initial orientation, currently just pitch (deg)
+% X - left/right, Y - up/down
+P0          = [0, 10]; % Initial position (m)
+V0          = [0, 0];  % Initial velocity (m/s)
+Orientation = [0];     % Initial orientation, currently just pitch (deg)
 
 StateVector = [P0, V0, Orientation];
 


### PR DESCRIPTION
This PR adds aircraft orientation to the State Vector. Currently, that is only the pitch but it is possible to easily add other rotations too. 
This doesn't do any math that uses (thrust) or calculates orientation (torque).

Closes #2.