### PR TITLE
(#25) Move Plotting functionality from TSoG_X1_Sim to TemplateTestCase

### DIFF
--- a/Simulation/StandardPlots.m
+++ b/Simulation/StandardPlots.m
@@ -10,12 +10,10 @@ function StandardPlots(Results)
   plot(Results.Time, Results.X);
   hold on;
   plot(Results.Time, Results.Vx);
-  hold on;
   plot(Results.Time, Results.Y);
-  hold on;
   plot(Results.Time, Results.Vy);
-  hold on;
   plot(Results.Time, Results.AoA);
+  hold off;
 
   xlabel('Time (s)');
 

--- a/Simulation/StandardPlots.m
+++ b/Simulation/StandardPlots.m
@@ -1,0 +1,27 @@
+% This is the standard/default plotting function you can use in your TestCase. 
+% It plots all simulation results to give you a quick overview of your data. 
+% It can also be used as a baseline or template for creating custom plotting functions.
+function StandardPlots(Results)
+  % Hack that helps with graph scaling
+  figure(1, 'position', [0, 0, 1920, 1000]);
+
+  set(groot, 'DefaultLineLineWidth', 5);
+
+  plot(Results.Time, Results.X);
+  hold on;
+  plot(Results.Time, Results.Vx);
+  hold on;
+  plot(Results.Time, Results.Y);
+  hold on;
+  plot(Results.Time, Results.Vy);
+  hold on;
+  plot(Results.Time, Results.AoA);
+
+  xlabel('Time (s)');
+
+  l = legend('Postion X (m)', 'Velocity X (m)', 'Position Y (m)', 'Velocity Y (m/s)', 'AoA (deg)');
+  set(l, 'FontSize', 25);
+  set(gca, 'FontSize', 25);
+
+  grid on;
+endfunction

--- a/Simulation/TSoG_X1_Sim.m
+++ b/Simulation/TSoG_X1_Sim.m
@@ -26,8 +26,6 @@ function [ Results ] = TSoG_X1_Sim( TestCase )
                               2 1;
                               15 1];
     TestCase.StopTime = 15;
-
-    TestCase.Plot = @StandardPlots;
   endif
 
   % Object parameters
@@ -100,6 +98,4 @@ function [ Results ] = TSoG_X1_Sim( TestCase )
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   %                        Simulation End
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-  TestCase.Plot(Results)
 endfunction

--- a/Simulation/TSoG_X1_Sim.m
+++ b/Simulation/TSoG_X1_Sim.m
@@ -3,7 +3,6 @@
 % or without an input Test Case (the sim will run with default inputs if no Test
 % Case is provided)
 
-
 function [ Results ] = TSoG_X1_Sim( TestCase )
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   %                        Simulation Setup
@@ -27,6 +26,8 @@ function [ Results ] = TSoG_X1_Sim( TestCase )
                               2 1;
                               15 1];
     TestCase.StopTime = 15;
+
+    TestCase.Plot = @StandardPlots;
   endif
 
   % Object parameters
@@ -100,26 +101,5 @@ function [ Results ] = TSoG_X1_Sim( TestCase )
   %                        Simulation End
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-  % Hack that helps with graph scaling
-  figure(1, 'position', [0, 0, 1920, 1000]);
-
-  set(groot, 'DefaultLineLineWidth', 5);
-
-  plot(Results.Time, Results.X);
-  hold on;
-  plot(Results.Time, Results.Vx);
-  hold on;
-  plot(Results.Time, Results.Y);
-  hold on;
-  plot(Results.Time, Results.Vy);
-  hold on;
-  plot(Results.Time, Results.AoA);
-
-  xlabel('Time (s)');
-
-  l = legend('Postion X (m)', 'Velocity X (m)', 'Position Y (m)', 'Velocity Y (m/s)', 'AoA (deg)');
-  set(l, 'FontSize', 25);
-  set(gca, 'FontSize', 25);
-
-  grid on;
+  TestCase.Plot(Results)
 endfunction

--- a/Testing/TemplateTestCase.m
+++ b/Testing/TemplateTestCase.m
@@ -2,6 +2,9 @@
 %
 % This template will establish the framework for creating test cases
 
+% Run the startup file to set up the `path`
+run('./startup.m');
+
 % Create a short name for the test case
 TestCase.Name        = 'Template';
 

--- a/Testing/TemplateTestCase.m
+++ b/Testing/TemplateTestCase.m
@@ -37,8 +37,9 @@ TestCase.ThrottleTable = [0 0;
 TestCase.StopTime = max([TestCase.ThrottleTable(end,1),TestCase.PitchTable(end,1)]);
 
 %% Run the Test Case through the Aircraft Simulation
+Results = TSoG_X1_Sim(TestCase);
 
-TestCase.Plot = @StandardPlots;
+StandardPlots(Results)
 
 % PLACE HOLDER PLOTS UNTIL SIMULATION INPUT IS ADDED
 
@@ -50,14 +51,14 @@ for i=1:length(time)
   Throttle(i,1) = FlightInputs.Throttle;
 endfor
 
-figure(1)
+figure(2)
 plot(time,Pitch)
 xlabel('Time (sec)')
 ylabel('Pitch (deg)')
 
 axis([0 max(time) 1.5*min(Pitch) 1.5*max(Pitch)])
 
-figure(2)
+figure(3)
 plot(time,Throttle*100)
 xlabel('Time (sec)')
 ylabel('Throttle (%)')

--- a/Testing/TemplateTestCase.m
+++ b/Testing/TemplateTestCase.m
@@ -38,6 +38,8 @@ TestCase.StopTime = max([TestCase.ThrottleTable(end,1),TestCase.PitchTable(end,1
 
 %% Run the Test Case through the Aircraft Simulation
 
+TestCase.Plot = @StandardPlots;
+
 % PLACE HOLDER PLOTS UNTIL SIMULATION INPUT IS ADDED
 
 time = 0:0.1:TestCase.StopTime;

--- a/Testing/startup.m
+++ b/Testing/startup.m
@@ -1,0 +1,1 @@
+addpath(genpath('../Simulation/'));


### PR DESCRIPTION
This allows every tests case to have a fully custom plotting function by assigning it to `TestCase.Plot` or a standard one that plots all simulation results by assigning `StandardPlots` to `TestCase.Plot`.

To run the whole simulation now, you have to:
```matlab
run("Testing/startup.m") % Only has to be run once per Octave session

run("Testing/TemplateTestCase.m")
```

Closes #25.