### PR TITLE
(#47) Convert FSM States from regular numbers into an Enum 

### DIFF
--- a/Simulation/Derivatives.m
+++ b/Simulation/Derivatives.m
@@ -25,7 +25,7 @@ function kOut = Derivatives(kn, SimData, weight)
   kOut.V_dot = Gravity + F / SimData.Plane.Mass; % Derivative of velocity is acceleration
 
   % Do not apply downward acceleration or velocity when on ground
-  if SimData.Plane.FSM_state == 0
+  if SimData.Plane.FSM_state == FSMStates.OnGround
     kOut.P_dot(2) = max(0, kOut.P_dot(2));
     kOut.V_dot(2) = max(0, kOut.V_dot(2));
   endif

--- a/Simulation/FSMStates.m
+++ b/Simulation/FSMStates.m
@@ -1,0 +1,14 @@
+%% FSM States
+% This is an enumeration of all states used by the FSM (finite state machine).
+
+% Note: enumerations are currently not implemented in Octave 
+% (https://savannah.gnu.org/bugs/?44582) so constant properties are used instead. 
+
+classdef FSMStates
+	properties (Constant)
+		OnGround = 0
+		Flying = 1
+		Cruising = 2
+		Crashed = 3
+	end
+end

--- a/Simulation/GetFSMState.m
+++ b/Simulation/GetFSMState.m
@@ -1,11 +1,5 @@
 ## Author: Aditya Ojha <Aditya Ojha@DESKTOP-CVU5H2C>
 ## Created: 2020-07-12
-% States are enumerated as such:
-% 0 = On the ground safely ==> just the initial state.
-%     when height is <= ground height and the vertical velocity is more than -5m/s
-% 1 = Flying  ==> height is > ground height and v_x is positive
-% 2 = Cruising ==> Still need to define
-% 3 = Crashed ==> when height is <= ground height and the vertical speed was less than -5m/s
 
 function next_state = GetFSMState(SimData)
     height = SimData.StateVector.Position(2);
@@ -15,32 +9,23 @@ function next_state = GetFSMState(SimData)
     ground_height = SimData.ground_height;
     last_state    = SimData.Plane.FSM_state;
 
-    %state transition boolean variables
-    flying = (height > ground_height) && (v_x > 0);
-    crashed = (height <= ground_height) && (v_y <= -5);
+    % State transition boolean variables
+    flying    = (height > ground_height)  && (v_x > 0);
+    crashed   = (height <= ground_height) && (v_y <= -5);
     on_ground = (height <= ground_height) && (v_y > -5);
 
-    %FSM state transition code
-    if last_state == 0 %if the plane is on the ground
-      %check if the plane is flying then if its crashed
-      if flying
-        next_state = 1;
-      elseif crashed
-        next_state = 3;
-      else
-        next_state = 0;
-      endif
-    elseif last_state == 1 %if the plane is flying
-      %check if the plane has crashed
-      if crashed
-        next_state = 3;
-      elseif on_ground
-        next_state = 0;
-      else
-        next_state = 1;
-      endif
-    elseif last_state == 3 %if the plane has crashed
-      %the plane cannot change states;
-      next_state = 3
+    if last_state == FSMStates.Crashed
+      % The plane cannot change states any more
+      next_state = FSMStates.Crashed;
+
+      return;
+    endif
+
+    if flying
+      next_state = FSMStates.Flying;
+    elseif crashed
+      next_state = FSMStates.Crashed;
+    else
+      next_state = FSMStates.OnGround;
     endif
 endfunction

--- a/Simulation/GetFSMState.m
+++ b/Simulation/GetFSMState.m
@@ -7,7 +7,7 @@
 % 2 = Cruising ==> Still need to define
 % 3 = Crashed ==> when height is <= ground height and the vertical speed was less than -5m/s
 
-function next_state = Get_FSM_State (SimData)
+function next_state = GetFSMState(SimData)
     height = SimData.StateVector.Position(2);
     v_x = SimData.StateVector.Velocity(1);
     v_y = SimData.StateVector.Velocity(2);

--- a/Simulation/RK4_Integration.m
+++ b/Simulation/RK4_Integration.m
@@ -30,7 +30,7 @@ function SimData = RK4_Integration(SimData)
 
     % Reset the altitude when we are on the ground to prevent the plane from 
     % going very slightly below the ground due to the discreteness of the simulation
-    if SimData.Plane.FSM_state == 0
+    if SimData.Plane.FSM_state == FSMStates.OnGround
         SimData.StateVector.Position(2) = SimData.ground_height;
     endif
 

--- a/Simulation/RK4_Integration.m
+++ b/Simulation/RK4_Integration.m
@@ -41,7 +41,7 @@ function SimData = RK4_Integration(SimData)
     SimData.StateVector.Orientation(1) = SimData.TestCase.GetPitch(SimData.Time);
 
     % Update FSM State of Plane
-    SimData.Plane.FSM_state = Get_FSM_State(SimData);
+    SimData.Plane.FSM_state = GetFSMState(SimData);
     flight_path_angle = atan2d(SimData.StateVector.Velocity(2), SimData.StateVector.Velocity(1));
     SimData.Plane.AoA = SimData.StateVector.Orientation(1) - flight_path_angle;
 

--- a/Simulation/TSoG_X1_Sim.m
+++ b/Simulation/TSoG_X1_Sim.m
@@ -65,7 +65,7 @@ function [ Results ] = TSoG_X1_Sim( TestCase, Plane )
   SimData.Plane = Plane;
 
   % Get initial state of the Plane
-  SimData.Plane.FSM_state = 0; % Assume the plane is on the ground before update
+  SimData.Plane.FSM_state = FSMStates.OnGround; % Assume the plane is on the ground before update
   SimData.Plane.FSM_state = GetFSMState(SimData);
 
   % Results used for plotting
@@ -102,7 +102,7 @@ function [ Results ] = TSoG_X1_Sim( TestCase, Plane )
     Results.ThrottleInput(i) = SimData.TestCase.GetThrottle(SimData.Time);
 
     % Check if object has crashed
-    if SimData.Plane.FSM_state == 3
+    if SimData.Plane.FSM_state == FSMStates.Crashed
         disp('Ground hit in ', num2str(Results.Time(end)), ' s');
         disp('Plane Crashed');
         break;

--- a/Simulation/TSoG_X1_Sim.m
+++ b/Simulation/TSoG_X1_Sim.m
@@ -66,7 +66,7 @@ function [ Results ] = TSoG_X1_Sim( TestCase, Plane )
 
   % Get initial state of the Plane
   SimData.Plane.FSM_state = 0; % Assume the plane is on the ground before update
-  SimData.Plane.FSM_state = Get_FSM_State(SimData);
+  SimData.Plane.FSM_state = GetFSMState(SimData);
 
   % Results used for plotting
   Results.X     = SimData.StateVector.Position(1);


### PR DESCRIPTION
This PR improves our FSM implementation in a few ways:
- FSM States are now stored in the `FSMStates` class that contains a constant property for each state. Enums are a lot less error prone and readable when working with compared to simple numbers. (Note: MATLAB enums are not supported in Octave as explained in the relevant comment)
- `Get_FSM_State` function is renamed to `GetFSMState` to better adhere to the naming convention of the rest of the project.
- `GetFSMState` function is also refactored to remove some redundancies and unnecessary comments due to the introduction of `FSMState` enumeration.

Closes #47.